### PR TITLE
event_download: Fix the cache directory creation

### DIFF
--- a/event_download.py
+++ b/event_download.py
@@ -44,8 +44,7 @@ def getdir():
         if not d:
             d = "%s/.cache/pmu-events" % (home)
         if not os.path.isdir(d):
-            os.mkdir("%s/.cache" % (home))
-            os.mkdir(d)
+            os.makedirs(d)
         return d
     except OSError:
         raise Exception('Cannot access ' + d) 


### PR DESCRIPTION
os.mkdir() will fail is the directory already exists. On the first
launch, $CACHEDIR is quite likely to exist, but not
$CACHEDIR/pmu-events and so getdir() will throw an exception on the
first os.mkdir().

Use os.makedirs() as it never fails (a la mkdir -p)

Signed-off-by: Damien Lespiau damien.lespiau@intel.com
