### PR TITLE
Added try/except for "Errata" KeyError

### DIFF
--- a/ocperf.py
+++ b/ocperf.py
@@ -238,8 +238,11 @@ class Emap(object):
                     d += " (Uses PEBS)"
                 else:
                     d = d.replace("(Precise Event)","") + " (Supports PEBS)"
-            if get('errata') != "null":
-                d += " Errata: " + get('errata')
+            try:
+                if get('errata') != "null":
+                    d += " Errata: " + get('errata')
+            except KeyError:
+                pass
             e.desc = d
             for (flag, name) in extra_flags:
                 if val & flag:


### PR DESCRIPTION
When I tried using ocperf, I was getting this error:

```
Traceback (most recent call last):
  File "./ocperf.py", line 561, in <module>
    emap = find_emap()
  File "./ocperf.py", line 403, in find_emap
    emap = json_with_offcore(el, True)
  File "./ocperf.py", line 370, in json_with_offcore
    emap = EmapNativeJSON(event_download.eventlist_name(el, "core"))
  File "./ocperf.py", line 333, in __init__
    return self.read_table(data, mapping)
  File "./ocperf.py", line 241, in read_table
    if get('errata') != "null":
  File "./ocperf.py", line 185, in <lambda>
    get = lambda (x): row[m[x]]
KeyError: u'Errata'
```

I wasn't sure if there was ever a case when the Errata field existed with the string "null" so I decided to try/except around the whole call. For reference, my system is using the GenuineIntel-6-2C-core.json file.

Thanks!
