### PR TITLE
tl-serve: Fix generating HTML files

### DIFF
--- a/tl-serve.py
+++ b/tl-serve.py
@@ -310,8 +310,8 @@ if args.gen:
     copyfile('toplev.ico', genfn(args.gen, 'favicon.ico'))
     for cpu in data.cpus:
         for l in data.levels:
-            with open(genfn(args.gen, cpu + ":" + l + ".csv"), 'w') as f:
-                gencsv(f, l)
+            with open(genfn(args.gen, cpu + "." + l + ".csv"), 'w') as f:
+                gencsv(f, l, cpu)
     print "Please browse", args.gen, "through a web server, not through file:"
 else:
     httpd = BaseHTTPServer.HTTPServer((args.host, args.port), TLHandler)


### PR DESCRIPTION
"tl-serve.py --gen" fails due to  missing argument when gencsv() is called
Also the generated files had   ":"  instead of "." in the name. 
C2:TopLevel.csv -> C2.TopLevel.csv 