### PR TITLE
simple-pebs: fix start_stop_cpu

### DIFF
--- a/simple-pebs/simple-pebs.c
+++ b/simple-pebs/simple-pebs.c
@@ -249,7 +249,7 @@ static void status_dump(char *where)
 
 static void start_stop_cpu(void *arg)
 {
-	wrmsrl(MSR_IA32_GLOBAL_CTRL, arg ? 0 : 1);
+	wrmsrl(MSR_IA32_GLOBAL_CTRL, arg ? 1 : 0);
 	status_dump("stop");
 }	
 


### PR DESCRIPTION
start_stop_cpu is called as

   smp_call_function_single(cpu, start_stop_cpu,
   	(void *)(long)(cmd == SIMPLE_PEBS_START), 1);

so we need to enable the counters if arg is true.