### PR TITLE
Reset stdin position so profiled application get correct input.

### DIFF
--- a/toplev.py
+++ b/toplev.py
@@ -305,6 +305,8 @@ p.add_argument('--bottleneck', help='Show critical bottleneck', action='store_tr
 args, rest = p.parse_known_args()
 
 rest = [x for x in rest if x != "--"]
+if not sys.stdin.isatty():
+    oldpos = sys.stdin.tell()
 
 if args.version:
     print "toplev"
@@ -498,6 +500,8 @@ class PerfRun:
         n = r.index("--log-fd")
         r[n + 1] = "%d" % (inp)
         print_perf(r)
+        if not sys.stdin.isatty():
+            sys.stdin.seek(oldpos)
         self.perf = subprocess.Popen(r)
         os.close(inp)
         return os.fdopen(outp, 'r')


### PR DESCRIPTION
If using no-multiplexing, profiled program may be executed for several times. If stdin is a file, after the first run, stdin should be reset before each run.