### PR TITLE
Fix rmap_event() to match target event provided

### DIFF
--- a/jevents/cache.c
+++ b/jevents/cache.c
@@ -232,7 +232,7 @@ int walk_events(int (*func)(void *data, char *name, char *event, char *desc),
 
 /**
  * rmap_event - Map numeric event back to name and description.
- * @event:  Event code (umask +
+ * @target:  Event code to match (umask + event).
  * @name: Put pointer to event name into this. No need to free.
  * @desc: Put pointer to description into this. No need to free. Can be NULL.
  *
@@ -242,7 +242,7 @@ int walk_events(int (*func)(void *data, char *name, char *event, char *desc),
  * Return: -1 on failure, otherwise 0.
  */
 
-int rmap_event(unsigned event, char **name, char **desc)
+int rmap_event(unsigned target, char **name, char **desc)
 {
 	struct event *e;
 	if (!eventlist_init) {
@@ -261,7 +261,7 @@ int rmap_event(unsigned event, char **name, char **desc)
 			s = strstr(e->event, "umask=");
 			if (s)
 				sscanf(s, "umask=%x", &umask);
-			if ((event | (umask << 8)) == (event & 0xffff)) {
+			if ((event | (umask << 8)) == (target & 0xffff)) {
 				*name = e->name;
 				if (desc)
 					*desc = e->desc;


### PR DESCRIPTION
The event-rmap program wasn't working correctly.  It would return "br_misp_retired.all_branches" for all queries:
```
nate@skylake:~/git/pmu-tools-nkurz/jevents$ ./listevents | grep interrupt
hw_interrupts.received                   cpu/umask=0x01,period=100003,event=0xcb/
nate@skylake:~/git/pmu-tools-nkurz/jevents$ ./showevent hw_interrupts.received
cpu/config=0x1cb,name=hw_interrupts.received/
nate@skylake:~/git/pmu-tools-nkurz/jevents$ ./event-rmap 0x1cb
1cb: br_misp_retired.all_branches : All mispredicted macro branch instructions retired
nate@skylake:~/git/pmu-tools-nkurz/jevents$ ./event-rmap 0x1
1: br_misp_retired.all_branches : All mispredicted macro branch instructions retired
```

The problem was a reuse of the variable name "event" in the rmap_event() function in cache.c.  It seems to work after fixing this:

```
nate@skylake:~/git/pmu-tools-nkurz/jevents$ ./event-rmap 0x1cb
1cb: hw_interrupts.received : Number of hardware interrupts received by the processor
nate@skylake:~/git/pmu-tools-nkurz/jevents$ ./event-rmap 0x1
1 not found
```