### PR TITLE
Quiet GCC 5.3 warnings for unused results and uninitialized variable

### DIFF
--- a/jevents/Makefile
+++ b/jevents/Makefile
@@ -2,7 +2,7 @@ PREFIX := /usr/local
 LIB := ${PREFIX}/lib64
 BIN := ${PREFIX}/bin
 INCLUDE := ${PREFIX}/include
-CFLAGS := -g -Wall -O2
+CFLAGS := -g -Wall -O2 -Wno-unused-result
 OBJ := json.o jsmn.o jevents.o resolve.o cache.o cpustr.o rawevent.o \
        perf-iter.o interrupts.o rdpmc.o measure.o perf_event_open.o \
        session.o

--- a/jevents/examples/Makefile
+++ b/jevents/examples/Makefile
@@ -1,5 +1,5 @@
 # build jevents first
-CFLAGS := -g -Wall -O2  -I ..
+CFLAGS := -g -Wall -O2  -I .. -Wno-unused-result
 CXXFLAGS := -g -Wall  -O2 
 LDFLAGS := -L ..
 LDLIBS = -ljevents

--- a/jevents/session.c
+++ b/jevents/session.c
@@ -79,6 +79,7 @@ int parse_events(struct eventlist *el, char *events)
 	char *s, *tmp;
 
 	events = strdup(events);
+	if (! events) return -1;
 	for (s = strtok_r(events, ",", &tmp);
 	     s;
 	     s = strtok_r(NULL, ",", &tmp)) {


### PR DESCRIPTION
Quiet a couple warnings so that real issues are more apparent.  Clang still has some other noisy warnings, and ICC doesn't like '-Wno-unused-result, but both compile.  