### PR TITLE
support haswell-ep and -ex

### DIFF
--- a/simple-pebs/simple-pebs.c
+++ b/simple-pebs/simple-pebs.c
@@ -140,7 +140,8 @@ static bool check_cpu(void)
 	
 	switch (model) { 
 	case 58: /* IvyBridge */
-	case 69: /* Haswell */
+	case 63: /* Haswell_EP */
+	case 69: /* Haswell_ULT */
 		pebs_event = 0x1c2; /* UOPS_RETIRED.ALL */
 		break;
 


### PR DESCRIPTION
Haswell_EP and _EX (Xeon E5 v3 and Xeon E7 v3) have the 0x1c2 counter as well, so they must be supported. I guess almost all recent models support 0x1c2, but many of them are missing.

However I just added model number 63 (Haswell_EP and _EX) because at least for this model I can be sure by actually measuring it.