### PR TITLE
const-correct event name in  resolve_event

### DIFF
--- a/jevents/cache.c
+++ b/jevents/cache.c
@@ -68,7 +68,7 @@ static struct event *eventlist[HASHSZ];
 static bool eventlist_init;
 
 /* Weinberg's identifier hash */
-static unsigned hashfn(char *s)
+static unsigned hashfn(const char *s)
 {
 	unsigned h = 0;
 	while (*s) {
@@ -165,7 +165,7 @@ static char *real_event(char *name, char *event)
  * Return: -1 on failure, otherwise 0.
  */
 
-int resolve_event(char *name, struct perf_event_attr *attr)
+int resolve_event(const char *name, struct perf_event_attr *attr)
 {
 	struct event *e;
 	char *buf;

--- a/jevents/jevents.h
+++ b/jevents/jevents.h
@@ -12,8 +12,8 @@ char *get_cpu_str_type(char *type);
 
 struct perf_event_attr;
 
-int jevent_name_to_attr(char *str, struct perf_event_attr *attr);
-int resolve_event(char *name, struct perf_event_attr *attr);
+int jevent_name_to_attr(const char *str, struct perf_event_attr *attr);
+int resolve_event(const char *name, struct perf_event_attr *attr);
 int read_events(char *fn);
 int walk_events(int (*func)(void *data, char *name, char *event, char *desc),
 		                void *data);

--- a/jevents/resolve.c
+++ b/jevents/resolve.c
@@ -87,7 +87,7 @@ static bool try_parse(char *format, char *fmt, __u64 val, __u64 *config)
 	return true;
 }
 
-static int read_qual(char *qual, struct perf_event_attr *attr)
+static int read_qual(const char *qual, struct perf_event_attr *attr)
 {
 	while (*qual) {
 		switch (*qual) { 
@@ -201,7 +201,7 @@ static int try_pmu_type(char **type, char *fmt, char *pmu)
  * attr->sample_type and attr->read_format as needed after this call,
  * and possibly other fields. Returns 0 when succeeded.
  */
-int jevent_name_to_attr(char *str, struct perf_event_attr *attr)
+int jevent_name_to_attr(const char *str, struct perf_event_attr *attr)
 {
 	char pmu[30], config[200];
 	int qual_off;


### PR DESCRIPTION
Since the string is only read, change char * to const char * for
const-correctness.