### PR TITLE
Provide necessary changes to build a libjevents RPM.

### DIFF
--- a/jevents/Makefile
+++ b/jevents/Makefile
@@ -1,8 +1,8 @@
-PREFIX := /usr/local
-LIB := ${PREFIX}/lib64
-BIN := ${PREFIX}/bin
-INCLUDE := ${PREFIX}/include
-CFLAGS := -g -Wall -O2 -Wno-unused-result
+PREFIX=$(DESTDIR)/usr/local
+LIB=$(PREFIX)/lib64
+BIN=$(PREFIX)/bin
+INCLUDE=$(PREFIX)/include
+CFLAGS := -g -fPIC -Wall -O2 -Wno-unused-result
 OBJ := json.o jsmn.o jevents.o resolve.o cache.o cpustr.o rawevent.o \
        perf-iter.o interrupts.o rdpmc.o measure.o perf_event_open.o \
        session.o

--- a/jevents/libjevents.spec
+++ b/jevents/libjevents.spec
@@ -3,7 +3,7 @@ Version:	1
 Release:	1%{?dist}
 Summary:	libjevents shared library from pmu-tools
 
-License:	GPL
+License:	BSD
 URL:		https://github.com/andikleen/pmu-tools/jevents
 # git clone https://github.com/andikleen/pmu-tools.git pmu-tools
 # cd pmu-tools && tar czf jevents.tar.gz jevents/
@@ -17,21 +17,19 @@ jevents library from pmu-tools.
 
 
 %build
-%make_build
+%make_build PREFIX=%{buildroot}/usr
 
 %install
-%make_install 
+%make_install PREFIX=%{buildroot}/usr
 
 %files
-/usr/local/bin/event-rmap
-/usr/local/bin/listevents
-/usr/local/bin/showevent
-/usr/local/include/jevents.h
-/usr/local/include/jsession.h
-/usr/local/include/measure.h
-/usr/local/include/perf-iter.h
-/usr/local/include/rdpmc.h
-/usr/local/lib64/libjevents.a
+/usr/bin/event-rmap
+/usr/bin/listevents
+/usr/bin/showevent
+/usr/include/
+/usr/lib64/libjevents.a
 
 %changelog
 
+* Sat Mar 3 2018 Pablo Llopis <pablo.llopis@gmail.com> 1-1
+- Initial specfile version

--- a/jevents/libjevents.spec
+++ b/jevents/libjevents.spec
@@ -1,0 +1,37 @@
+Name:		libjevents
+Version:	1
+Release:	1%{?dist}
+Summary:	libjevents shared library from pmu-tools
+
+License:	GPL
+URL:		https://github.com/andikleen/pmu-tools/jevents
+# git clone https://github.com/andikleen/pmu-tools.git pmu-tools
+# cd pmu-tools && tar czf jevents.tar.gz jevents/
+Source0:	jevents.tar.gz
+
+%description
+jevents library from pmu-tools.
+
+%prep
+%setup -q -n jevents
+
+
+%build
+%make_build
+
+%install
+%make_install 
+
+%files
+/usr/local/bin/event-rmap
+/usr/local/bin/listevents
+/usr/local/bin/showevent
+/usr/local/include/jevents.h
+/usr/local/include/jsession.h
+/usr/local/include/measure.h
+/usr/local/include/perf-iter.h
+/usr/local/include/rdpmc.h
+/usr/local/lib64/libjevents.a
+
+%changelog
+


### PR DESCRIPTION
This commit provides two things. First, changes to the Makefile: adds
-fPIC to the CFLAGS so others can link to the library correctly, and
fixes the PREFIX to use DESTDIR so rpmbuild will work correctly.
Second, a minimum specfile necessary to build the RPM.