### PR TITLE
unistd.h location change

### DIFF
--- a/jevents/perf-iter.c
+++ b/jevents/perf-iter.c
@@ -26,7 +26,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <sys/unistd.h>
 #include <sys/ioctl.h>
 #include "jevents.h"
 


### PR DESCRIPTION
unistd.h is included twice. In case of alpine 3.7 with musl C, the unistd.h does not reside under <sys>