### PR TITLE
remove pmu arg from callback in walk_perf_events, fixes #142

### DIFF
--- a/jevents/Makefile
+++ b/jevents/Makefile
@@ -1,3 +1,4 @@
+.PHONY = all clean-examples all-examples install clean html man
 PREFIX=$(DESTDIR)/usr/local
 LIB=$(PREFIX)/lib64
 BIN=$(PREFIX)/bin
@@ -13,7 +14,7 @@ all: libjevents.a showevent listevents event-rmap all-examples
 clean-examples:
 	make -C examples clean
 
-all-examples:
+all-examples: libjevents.a
 	make -C examples
 
 install: libjevents.a listevents showevent event-rmap

--- a/jevents/cache.c
+++ b/jevents/cache.c
@@ -130,8 +130,11 @@ static void free_events(void)
  */
 int read_events(char *fn)
 {
-	if (!eventlist_init)
+	if (eventlist_init) {
+	    // treat subsequent read_events calls after the first as replacing the
+	    // event list
 		free_events();
+	}
 	eventlist_init = true;
 	/* ??? free on error */
 	return json_events(fn, collect_events, NULL);

--- a/jevents/resolve.c
+++ b/jevents/resolve.c
@@ -29,6 +29,7 @@
 */
 
 #define _GNU_SOURCE 1
+#include "jevents.h"
 #include <linux/perf_event.h>
 #include <stdio.h>
 #include <string.h>
@@ -240,7 +241,7 @@ int jevent_name_to_attr(const char *str, struct perf_event_attr *attr)
  * @func: Callback function to call for each event.
  * @data: data pointer to pass to func.
  */
-int walk_perf_events(int (*func)(void *data, char *name, char *event, char *desc, char *pmu),
+int walk_perf_events(int (*func)(void *data, char *name, char *event, char *desc),
 		     void *data)
 {
 	int ret = 0;
@@ -276,7 +277,7 @@ int walk_perf_events(int (*func)(void *data, char *name, char *event, char *desc
 
 		char *buf;
 		asprintf(&buf, "%s/%s/", pmu, event);
-		ret = func(data, buf, val2, "", pmu);
+		ret = func(data, buf, val2, "");
 		free(val2);
 		free(buf);
 		if (ret)

--- a/jevents/resolve.c
+++ b/jevents/resolve.c
@@ -74,7 +74,7 @@ static int read_file(char **val, const char *fmt, ...)
 	return ret;
 }
 
-#define BITS(x) ((1U << (x)) - 1)
+#define BITS(x) ((x) == 64 ? -1UL : (1UL << (x)) - 1)
 
 static bool try_parse(char *format, char *fmt, __u64 val, __u64 *config)
 {


### PR DESCRIPTION
As discussed, remove the `pmu` parameter, add header.