### PR TITLE
free existing cache on subsequent read_events calls

### DIFF
--- a/jevents/cache.c
+++ b/jevents/cache.c
@@ -130,8 +130,11 @@ static void free_events(void)
  */
 int read_events(char *fn)
 {
-	if (!eventlist_init)
+	if (eventlist_init) {
+	    // treat subsequent read_events calls after the first as replacing the
+	    // event list
 		free_events();
+	}
 	eventlist_init = true;
 	/* ??? free on error */
 	return json_events(fn, collect_events, NULL);


### PR DESCRIPTION
Potentially fixes #146 , see the discussion in that issue.