### PR TITLE
Add proper error propagation and option for absolute values

### DIFF
--- a/snb_client_ratios.py
+++ b/snb_client_ratios.py
@@ -107,6 +107,7 @@ def Memory_Bound_Fraction(self, EV, level):
     return (STALLS_MEM_ANY(self, EV, level) + EV("RESOURCE_STALLS.SB", level)) / Backend_Bound_Cycles(self, EV, level)
 
 def Mem_L3_Hit_Fraction(self, EV, level):
+    """formula from https://software.intel.com/en-us/blogs/2013/07/01/estimate-the-penalty-of-cache-miss-more-accurate-on-ivy-bridge"""
     return EV("MEM_LOAD_UOPS_RETIRED.LLC_HIT", level) /(EV("MEM_LOAD_UOPS_RETIRED.LLC_HIT", level) + Mem_L3_Weight * EV("MEM_LOAD_UOPS_MISC_RETIRED.LLC_MISS", level))
 
 def Mispred_Clears_Fraction(self, EV, level):

--- a/tl_output.py
+++ b/tl_output.py
@@ -40,9 +40,8 @@ class Output:
     def set_cpus(self, cpus):
         pass
 
-    def item(self, area, name, uval, absval, timestamp, remark, desc, title, sample, bn):
+    def item(self, area, name, uval, timestamp, remark, desc, title, sample, bn):
         assert isinstance(uval, UVal)
-        assert absval is None or isinstance(absval, UVal)
         # --
         if desc in self.printed_descs:
             desc = ""
@@ -50,17 +49,15 @@ class Output:
             self.printed_descs.add(desc)
         if not area:
             area = ""
-        self.show(timestamp, title, area, name, uval, absval, remark, desc, sample, bn)
+        self.show(timestamp, title, area, name, uval, remark, desc, sample, bn)
 
-    def ratio(self, area, name, uval, absval, timestamp, unit, desc, title, sample, bn):
+    def ratio(self, area, name, uval, timestamp, remark, desc, title, sample, bn):
         uval.is_ratio = True
-        self.item(area, name, uval, absval, timestamp, "%" + unit, desc, title, sample, bn)
+        self.item(area, name, uval, timestamp, "%" + remark, desc, title, sample, bn)
 
     def metric(self, area, name, uval, timestamp, desc, title, unit):
         uval.is_metric = True
-        assert isinstance(uval, UVal)
-        # --
-        self.item(area, name, uval, None, timestamp, unit, desc, title, None, "")
+        self.item(area, name, uval, timestamp, unit, desc, title, None, "")
 
     def flush(self):
         pass
@@ -110,7 +107,7 @@ class OutputHuman(Output):
     # bn        marker for bottleneck
     # Example:
     # C0    BE      Backend_Bound:                                62.00 %
-    def show(self, timestamp, title, area, hdr, val, absval, remark, desc, sample, bn):
+    def show(self, timestamp, title, area, hdr, val, remark, desc, sample, bn):
         self.print_timestamp(timestamp)
         write = self.logf.write
         if title:
@@ -120,16 +117,13 @@ class OutputHuman(Output):
                                                  val.format_uncertainty(),
                                                  remark,
                                                  width=self.unitlen + 1)
-        if absval is not None:
-            val += "  || {:>16} +- {:>16}".format(absval.format_value(),
-                                                  absval.format_uncertainty())
         if bn:
             val += " " + bn
         write(val + "\n")
         self.print_desc(desc, sample)
 
     def metric(self, area, name, l, timestamp, desc, title, unit):
-        self.item(area, name, l, None, timestamp, unit, desc, title, None, "")
+        self.item(area, name, l, timestamp, unit, desc, title, None, "")
 
 def convert_ts(ts):
     if isnan(ts):
@@ -148,16 +142,16 @@ class OutputColumns(OutputHuman):
     def set_cpus(self, cpus):
         self.cpunames = cpus
 
-    def show(self, timestamp, title, area, hdr, val, absval, remark, desc, sample, bn):
+    def show(self, timestamp, title, area, hdr, val, remark, desc, sample, bn):
         if self.args.single_thread:
-            OutputHuman.show(self, timestamp, title, area, hdr, val, absval, remark, desc, sample, bn)
+            OutputHuman.show(self, timestamp, title, area, hdr, val, remark, desc, sample, bn)
             return
         self.timestamp = timestamp
         key = (area, hdr)
         if key not in self.nodes:
             self.nodes[key] = dict()
         assert title not in self.nodes[key]
-        self.nodes[key][title] = (val, remark, desc, sample, bn)  # FIXME: use absval
+        self.nodes[key][title] = (val, remark, desc, sample, bn)
 
     def flush(self):
         VALCOL_LEN = 14
@@ -215,13 +209,13 @@ class OutputColumnsCSV(OutputColumns):
         self.writer.writerow(["# " + version + " on " + cpu.name])
 
     # XXX implement bn
-    def show(self, timestamp, title, area, hdr, val, absval, remark, desc, sample, bn):
+    def show(self, timestamp, title, area, hdr, val, remark, desc, sample, bn):
         self.timestamp = timestamp
         key = (area, hdr)
         if key not in self.nodes:
             self.nodes[key] = dict()
         assert title not in self.nodes[key]
-        self.nodes[key][title] = (val, remark, desc, sample)  # FIXME: use absval
+        self.nodes[key][title] = (val, remark, desc, sample)
 
     def flush(self):
         cpunames = sorted(self.cpunames)
@@ -244,6 +238,7 @@ class OutputColumnsCSV(OutputColumns):
                         desc = re.sub(r"\s+", " ", desc)
                     if cpu[3]:
                         sample = cpu[3]
+                    # ignore remark for now
                     vlist.append(cpu[0])
                     ol[cpuname] = float(cpu[0].value)
             l += [ol[x] if x in ol else "" for x in cpunames]
@@ -265,7 +260,7 @@ class OutputCSV(Output):
         self.args = args
         self.writer.writerow(["# " + version + " on " + cpu.name])
 
-    def show(self, timestamp, title, area, hdr, val, absval, remark, desc, sample, bn):
+    def show(self, timestamp, title, area, hdr, val, remark, desc, sample, bn):
         if self.args.no_desc:
             desc = ""
         desc = re.sub(r"\s+", " ", desc)

--- a/tl_stat.py
+++ b/tl_stat.py
@@ -17,29 +17,23 @@ from collections import namedtuple
 
 ValStat = namedtuple('ValStat', ['stddev', 'multiplex'])
 
+
+def isnan(x):
+    return x != x
+
+
 def geoadd(l):
     return math.sqrt(sum([x**2 for x in l]))
 
+
 # use geomean of stddevs and minimum of multiplex ratios for combining
 # XXX better way to combine multiplex ratios?
+# TODO: this is in general wrong. geoadd only is true for mult?? need error propagation
 def combine_valstat(l):
     if not l:
         return []
     return ValStat(geoadd([x.stddev for x in l]), min([x.multiplex for x in l]))
 
-def isnan(x):
-    return x != x
-
-def format_valstat(valstat):
-    vs = ""
-    if valstat:
-        if valstat.stddev:
-            vs += "+-%6.2f " % valstat.stddev
-        if valstat.multiplex and not isnan(valstat.multiplex):
-            vs += "[%6.2f%%]" % valstat.multiplex
-    if vs:
-        vs = "%8s" % vs
-    return vs
 
 class ComputeStat:
     """Maintain statistics on measurement data."""

--- a/tl_stat.py
+++ b/tl_stat.py
@@ -17,23 +17,19 @@ from collections import namedtuple
 
 ValStat = namedtuple('ValStat', ['stddev', 'multiplex'])
 
-
-def isnan(x):
-    return x != x
-
-
 def geoadd(l):
     return math.sqrt(sum([x**2 for x in l]))
 
-
+# DEPRECATED
 # use geomean of stddevs and minimum of multiplex ratios for combining
 # XXX better way to combine multiplex ratios?
-# TODO: this is in general wrong. geoadd only is true for mult?? need error propagation
-def combine_valstat(l):
+def deprecated_combine_valstat(l):
     if not l:
         return []
     return ValStat(geoadd([x.stddev for x in l]), min([x.multiplex for x in l]))
 
+def isnan(x):
+    return x != x
 
 class ComputeStat:
     """Maintain statistics on measurement data."""

--- a/tl_uval.py
+++ b/tl_uval.py
@@ -67,7 +67,7 @@ class UVal:
         if self.stddev is not None:
             if self.is_ratio:
                 if self.value != 0.:
-                    v = self.stddev / self.value * 100.
+                    v = self.stddev * 100.
                 else:
                     v = 0.
                 vs += "{:.2f}".format(v)

--- a/tl_uval.py
+++ b/tl_uval.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2018 Technical University of Munich
+# Author: Martin Becker
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+import math
+import logging
+import operator
+
+
+log = logging.getLogger(__name__)
+TEMPVAL = 'anon'
+
+
+class UVal:
+    """
+    Measurement value annotated with uncertainty. Supports binary operators for error propagation.
+    """
+
+    def __init__(self, name, value, stddev=0., samples=1, comment="", computed=False):
+        self.name = name
+        self.comment = comment
+        self.value = value
+        self.stddev = stddev
+        self.samples = samples
+        self.computed = computed
+        self.used = False
+
+    def __repr__(self):
+        return "{} [{} +- {}]*{}".format(self.name, self.value, self.stddev, self.samples)
+
+    def set_desc(self, name, comment):
+        """set name and description in one go"""
+        self.name = name
+        self.comment = comment
+
+    def update(self, other):
+        """merge data from other event into this"""
+        assert isinstance(other, UVal), "wrong type"
+        # --
+        # calc weighted average
+        n = self.samples + other.samples
+        res = (1. / n) * (self.samples * self + other.samples * other)
+        strbefore = "{}".format(self)
+        # apply 'res' to this
+        self.samples = n
+        self.value = res.value
+        self.stddev = res.stddev
+        log.warning("updated {} with {} => {}".format(strbefore, other, self))
+
+    ######################
+    # same-type operators
+    ######################
+
+    def __sub__(self, other):
+        """self - other"""
+        if isinstance(other, UVal):
+            o = other
+        elif isinstance(other, (float, int)):
+            o = UVal(TEMPVAL, value=other, stddev=0)
+        else:
+            return NotImplemented
+        return self._calc(operator.sub, self, o)
+
+    def __add__(self, other):
+        """self + other"""
+        if isinstance(other, UVal):
+            o = other
+        elif isinstance(other, (float, int)):
+            o = UVal(TEMPVAL, value=other, stddev=0)
+        else:
+            return NotImplemented
+        return self._calc(operator.add, self, o)
+
+    def __mul__(self, other):
+        """self * other"""
+        if isinstance(other, UVal):
+            o = other
+        elif isinstance(other, (float, int)):
+            o = UVal(TEMPVAL, value=other, stddev=0)
+        else:
+            return NotImplemented
+        return self._calc(operator.mul, self, o)
+
+    def __div__(self, other):
+        """self / other"""
+        if isinstance(other, UVal):
+            o = other
+        elif isinstance(other, (float, int)):
+            o = UVal(TEMPVAL, value=other, stddev=0)
+        else:
+            return NotImplemented
+        return self._calc(operator.div, self, o)
+
+    #######################
+    # mixed-type operators
+    #######################
+
+    def __rsub__(self, other):
+        """other - self"""
+        tmp = UVal(TEMPVAL, value=other, stddev=0)
+        return self._calc(operator.sub, tmp, self)
+
+    def __rmul__(self, other):
+        """other * self"""
+        tmp = UVal(TEMPVAL, value=other, stddev=0)
+        return self._calc(operator.mul, tmp, self)
+
+    #########################
+    # uncertainty propagator
+    #########################
+
+    def _calc(ev, op, lhs, rhs, cov=0.):
+        """Compute the result of 'lhs [op] rhs' and propagate standard deviations"""
+        lhs.used = rhs.used = True
+        A = lhs.value
+        B = rhs.value
+        a = lhs.stddev
+        b = rhs.stddev
+        # new value
+        f = op(float(A), B)
+        if isinstance(f, float) and f.is_integer(): f = int(f)
+        # uncertainty: FIXME covariance neglected
+        if op in (operator.mul, operator.truediv, operator.div):
+            sgn = 1 if op == operator.mul else -1
+            if A != 0 and B != 0:
+                u = abs(f) * math.sqrt(pow(float(a)/A, 2) + pow(float(b)/B, 2) + sgn*2.*cov/(A*B))
+            elif op == operator.mul:
+                u = 0.
+            elif op == operator.div:
+                u = 0.
+                if A != 0:
+                    log.warning("Error prop failed because of DIV/0: {} {} {}".format(lhs, op, rhs))
+
+        elif op in (operator.add, operator.sub):
+            sgn = 1 if op == operator.add else -1
+            u = math.sqrt(pow(a, 2) + pow(b, 2) + sgn*2.*cov)
+
+        else:
+            u = None
+            log.error("Unsupported operation for uncertainty propagator in {} {} {}".format\
+                      (lhs, op, rhs))
+        # --
+        ret = UVal(TEMPVAL, value=f, stddev=u, computed=True)
+        log.debug("{} {} {} => {}".format(lhs, op, rhs, ret))
+        return ret


### PR DESCRIPTION
This PR consists of one upgrade for the statistics ~~and one new cmd line option~~.

### Uncertainty Propagation
For calculations that are being made, the standard deviation and mux are now [properly tracked](https://en.wikipedia.org/w/index.php?title=Propagation_of_uncertainty&oldid=858197377), so that the final result shows ratios +/- error margins, e.g.: 
```
FE             Frontend_Bound:                     14.35 +-     0.35 % Slots below           
BAD            Bad_Speculation:                     0.73 +-     0.45 % Slots below           
BE             Backend_Bound:                      49.01 +-     0.66 % Slots                 
RET            Retiring:                           35.94 +-     0.33 % Slots below
```
A simplistic version of this was already present before, but the errors were incorrectly computed and thus not meaningful. This is a better way to do it. Towards this, all measurement values were wrapped into a class `UVal`, which overloads binary operators and propagates the stddev and multiplex ratio along with the actual values. This new class also provides some formatting functions for the output classes.

### ~~Option to show absolute values~~ withdrawn, see discussion
A new command line option `--absval` has been added, which displays the absolute values of all ratios, computed by mutliplying the ratio with the clock ticks. For this one, I am not sure if my interpretation is correct when it comes to stalls. Example:

```
FE             Frontend_Bound.Frontend_Latency.ITLB_Misses:              0.17 +-     0.03 % Clocks below            ||       56,673,335 +-     9,017,420.56
FE             Frontend_Bound.Frontend_Latency.Branch_Resteers:          0.26 +-     0.04 % Clocks_Estimated below  ||       85,922,773 +-    12,487,129.47
FE             Frontend_Bound.Frontend_Latency.DSB_Switches:             0.04 +-     0.00 % Clocks below            ||       14,268,506 +-       877,964.28
FE             Frontend_Bound.Frontend_Latency.LCP:                      0.00 +-     0.00 % Clocks below            ||                0 +-             0.00

```