### PR TITLE
Fix not subscriptable map error

### DIFF
--- a/toplev.py
+++ b/toplev.py
@@ -280,7 +280,7 @@ class PerfFeatures(object):
                 and os.path.exists("/sys/devices/power/events/energy-cores"))
         with os.popen(self.perf + " --version") as f:
             v = f.readline().split()
-            perf_version = map(int, (v[2]).split("."))[:2] if len(v) >= 3 else (0,0)
+            perf_version = tuple(map(int, (v[2]).split(".")))[:2] if len(v) >= 3 else (0,0)
 
         self.supports_percore = (perf_version >= (5,7) or
                                  works(self.perf + " stat --percore-show-thread true"))


### PR DESCRIPTION
map(...) returns an iterable object that must be converted to a tuple when using python 3.

Tested on:
- Ubuntu 21.04
- Linux 5.11.0-31-generic
- Python 3.9.5