### PR TITLE
jevents: fix some stability issues

### DIFF
--- a/jevents/jevents.c
+++ b/jevents/jevents.c
@@ -355,6 +355,8 @@ int json_events(const char *fn,
 			addfield(map, &event, ",", msr->pname, msrval);
 		if (!pmu)
 			pmu = strdup("cpu");
+		if (!desc)
+			desc = strdup("No description.");
 		err = -EIO;
 		if (name && event) {
 			fixname(name);

--- a/jevents/json.c
+++ b/jevents/json.c
@@ -81,7 +81,7 @@ jsmntok_t *parse_json(const char *fn, char **map, size_t *size, int *len)
 		return NULL;
 	/* Heuristic */
 	sz = *size * 16;
-	tokens = malloc(sz);
+	tokens = calloc(1, sz);
 	if (!tokens)
 		goto error;
 	jsmn_init(&parser);

--- a/jevents/resolve.c
+++ b/jevents/resolve.c
@@ -373,7 +373,10 @@ void jevent_copy_extra(struct jevent_extra *dst, struct jevent_extra *src)
 	dst->pmus.gl_pathc = src->pmus.gl_pathc;
 	len = sizeof(char *) * src->pmus.gl_pathc;
 	dst->pmus.gl_pathv = malloc(len);
-	memcpy(dst->pmus.gl_pathv, src->pmus.gl_pathv, len);
+	size_t i;
+	for (i = 0; i < src->pmus.gl_pathc; i++) {
+		dst->pmus.gl_pathv[i] = strdup(src->pmus.gl_pathv[i]);
+	}
 }
 
 /**


### PR DESCRIPTION
Fix double free in resolve.c:
There is possible double free when calling ``` jevent_free_extra ```.
The memory is allocated in ```jevent_copy_extra```. The ```gl_pathv``` in ```glob_t``` is an array of char pointers. The function copied the pointers, but not the strings they point to. Later when memory was freed with ```globfree``` in ```jevent_free_extra()``` it could cause double free and undefined behavior. Now the strings pointed in array are copied one by one.

Fix possible issue with providing null pointer to ```strdup``` in jevents.c.
If event description was missing in input JSON file, the ```desc``` variable was left as NULL in ```json_events()```. It was later provided to ```strdup``` in ```collect_events()```. Now the ```desc``` is initialized to default string if not found in JSON file.

Fix issue with conditional jump or move depends on uninitialised value. The issue was detected by valgrind.
```
Conditional jump or move depends on uninitialised value(s)
at 0x405B89: countchar (json.c:114)
by 0x405B89: json_line (json.c:123)
by 0x403675: json_events (jevents.c:268)
...
```
