### PR TITLE
Grouped Multi-PMU Events

### DIFF
--- a/jevents/resolve.c
+++ b/jevents/resolve.c
@@ -551,7 +551,7 @@ int jevent_name_to_attr_extra(const char *str, struct perf_event_attr *attr,
 				return -1;
 			if (try_pmu_type(&type, strrchr(extra->pmus.gl_pathv[0], '/'), pmu, NULL) < 0)
 				goto err_free;
-			extra->next_pmu = 1;
+			extra->next_pmu = 0;
 			extra->multi_pmu = true;
 		}
 	}


### PR DESCRIPTION
This PR includes one bug fix and one major feature:
1. In `resolve.c`, we initialized `next_pmu` to `1`, which causes all but the first PMU to collect the event: I didn't notice this until I finished implementing this feature.
2. Added support for grouped multi-PMU events.