### PR TITLE
Fix "Unknown node(s)" diagnostic

### DIFF
--- a/toplev.py
+++ b/toplev.py
@@ -3100,7 +3100,7 @@ def check_nodes(runner_list, nodesarg):
                     return True
         return False
 
-    valid = [o for o in options if valid_node(o)]
+    valid = list(map(valid_node, options))
     if not all(valid):
         sys.exit("Unknown node(s) in --nodes: " +
                  " ".join([o for o, v in zip(options, valid) if not v]))


### PR DESCRIPTION
Currently invalid nodes are not caught, and before 1c232723 they were caught
but not printed because the map object was consumed by "all".

This uses map to compute "valid" again, as before 1c232723, but promotes the map
object to a list so that it can be evaluated more than once.