### PR TITLE
event_download: Fetch events from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ or symlink the tool you're interested in to /usr/local/bin or ~/bin. The tools a
 find their python dependencies.
 
 When first run, toplev / ocperf will automatically download the Intel event lists from
-https://download.01.org. This requires working internet access. Later runs can
+https://github.com/intel/perfmon. This requires working internet access. Later runs can
 be done offline. It's also possible to download the event lists ahead, see
 [pmu-tools offline](https://github.com/andikleen/pmu-tools/wiki/Running-ocperf-toplev-when-not-on-the-internet)
 

--- a/event_download.py
+++ b/event_download.py
@@ -207,8 +207,9 @@ def parse_map_file(match, key=None, link=True, onlyprint=False,
                     print("Cannot link %s to %s:" % (name, lname), e, file=sys.stderr)
             files.append(fn)
         models.close()
-        if not onlyprint and not os.path.exists(os.path.join(dirfn, "readme.txt")) and not mfn:
-            getfile(urlpath + "/readme.txt", dirfn, "readme.txt")
+        for file_name in ["README.md", "LICENSE"]:
+            if not onlyprint and not os.path.exists(os.path.join(dirfn, file_name)) and not mfn:
+                getfile(urlpath + "/" + file_name, dirfn, file_name)
     except URLError as e:
         print("Cannot access event server:", e, file=sys.stderr)
         warn_once("""

--- a/event_download.py
+++ b/event_download.py
@@ -32,7 +32,7 @@ import os
 import string
 from fnmatch import fnmatch
 
-urlpath = 'https://download.01.org/perfmon'
+urlpath = 'https://raw.githubusercontent.com/intel/perfmon/main'
 mapfile = 'mapfile.csv'
 modelpath = urlpath + "/" + mapfile
 

--- a/jevents/cache.c
+++ b/jevents/cache.c
@@ -50,7 +50,7 @@
  * The standard workflow is the user calling "event_download.py"
  * to download the current list, and then
  * these functions can resolve or walk names. Alternatively
- * a JSON event file from https://download.01.org/perfmon
+ * a JSON event file from https://github.com/intel/perfmon
  * can be specified through the EVENTMAP= environment variable.
  */
 


### PR DESCRIPTION
Hi Andi,

This pull request swaps the previous download.01.org URL with GitHub. We merged `readme.txt` into `README.md` and those file paths are updated here as well. Please review when you get a minute. Additional steps/details are also tracked in the parent issue at https://github.com/intel/perfmon/issues/17 . Sorry again about any extra work or interruption this causes.

```
ed@ebaker-MOBL3:~/pmu-tools$ rm -r ~/.cache/pmu-events/

ed@ebaker-MOBL3:~/pmu-tools$ ./event_download.py -a
Downloading https://raw.githubusercontent.com/intel/perfmon/main/mapfile.csv to mapfile.csv
Downloading https://raw.githubusercontent.com/intel/perfmon/main/NHM-EX/events/NehalemEX_core.json to GenuineIntel-6-2E-core.json
Downloading https://raw.githubusercontent.com/intel/perfmon/main/NHM-EP/events/NehalemEP_core.json to GenuineIntel-6-1E-core.json
Downloading https://raw.githubusercontent.com/intel/perfmon/main/NHM-EP/events/NehalemEP_core.json to GenuineIntel-6-1F-core.json
Downloading https://raw.githubusercontent.com/intel/perfmon/main/NHM-EP/events/NehalemEP_core.json to GenuineIntel-6-1A-core.json
<snip>
Downloading https://raw.githubusercontent.com/intel/perfmon/main/ADL/events/alderlake_uncore.json to GenuineIntel-6-BE-uncore.json
Downloading https://raw.githubusercontent.com/intel/perfmon/main/MTL/events/meteorlake_crestmont_core.json to GenuineIntel-6-AA-hybridcore.json
Downloading https://raw.githubusercontent.com/intel/perfmon/main/MTL/events/meteorlake_redwoodcove_core.json to GenuineIntel-6-AA-hybridcore.json
Downloading https://raw.githubusercontent.com/intel/perfmon/main/README.md to README.md
Downloading https://raw.githubusercontent.com/intel/perfmon/main/LICENSE to LICENSE
my event list /home/ed/.cache/pmu-events/GenuineIntel-6-8E-core.json
```