### PR TITLE
event_download: Allow specifying path to perfmon dir

### DIFF
--- a/event_download.py
+++ b/event_download.py
@@ -20,6 +20,7 @@
 # env:
 # CPUINFO=... override /proc/cpuinfo file
 # MAPFILE=... override mapfile.csv
+# PERFMONDIR=... override download prefix for perfmon data, can be a local clone (file:///tmp/perfmon)
 from __future__ import print_function
 import sys
 import re

--- a/event_download.py
+++ b/event_download.py
@@ -32,7 +32,7 @@ import os
 import string
 from fnmatch import fnmatch
 
-urlpath = 'https://raw.githubusercontent.com/intel/perfmon/main'
+urlpath = os.environ.get('PERFMONDIR', 'https://raw.githubusercontent.com/intel/perfmon/main')
 mapfile = 'mapfile.csv'
 modelpath = urlpath + "/" + mapfile
 


### PR DESCRIPTION
With the event defintions now hosted on Github it is now fairly simple
to download all CPU definitions in one go.

This patch allows overriding the download prefix url via an env var
allowing an easier offline workflow:

Some offline version of this, e.g.: download the zips from github

```
/tmp/offline$ git clone https://github.com/intel/perfmon
/tmp/offline$ git clone https://github.com/andikleen/pmu-tools
```

followed by

```
/tmp/offline$ PERFMONDIR=file:///tmp/offline/perfmon ./pmu-tools/event_download.py
Downloading file:///tmp/offline/perfmon/mapfile.csv to mapfile.csv
Downloading file:///tmp/offline/perfmon/ADL/events/alderlake_gracemont_core.json to GenuineIntel-6-97-hybridcore.json
Downloading file:///tmp/offline/perfmon/ADL/events/alderlake_goldencove_core.json to GenuineIntel-6-97-hybridcore.json
Downloading file:///tmp/offline/perfmon/ADL/events/alderlake_uncore.json to GenuineIntel-6-97-uncore.json
Downloading file:///tmp/offline/perfmon/ADL/events/alderlake_uncore_experimental.json to GenuineIntel-6-97-uncoreexperimental.json
Downloading file:///tmp/offline/perfmon/README.md to README.md
Downloading file:///tmp/offline/perfmon/LICENSE to LICENSE
```

This avoids two issues related to using toplev offline:

 - No need to find out the GenuineIntel-XXX id
 - No need to have an internet connected machine that matches the target
   machine and can run python