### PR TITLE
ocperf: Retrieve events from updated JSON structure

### DIFF
--- a/ocperf.py
+++ b/ocperf.py
@@ -573,7 +573,12 @@ def json_open(name):
     d = open(name, "rb").read()
     if not isinstance(d, str):
         d = d.decode('utf-8')
-    return json.loads(d)
+
+    json_data = json.loads(d)
+    if 'Events' in json_data:
+        json_data = json_data['Events']
+
+    return json_data
 
 class EmapNativeJSON(object):
     """Read an event table."""

--- a/ocperf.py
+++ b/ocperf.py
@@ -575,7 +575,7 @@ def json_open(name):
         d = d.decode('utf-8')
 
     json_data = json.loads(d)
-    if 'Events' in json_data:
+    if isinstance(json_data, dict) and 'Events' in json_data:
         json_data = json_data['Events']
 
     return json_data


### PR DESCRIPTION
Recently a Header was introduced to Intel event files [1]. This commit checks for the presence of the new structure and pulls events from 'Events' accordingly.

[1] https://github.com/intel/perfmon/issues/22