### PR TITLE
pebs v3 support

### DIFF
--- a/pebs-grabber/pebs-grabber.c
+++ b/pebs-grabber/pebs-grabber.c
@@ -15,7 +15,7 @@
    make [KDIR=/my/kernel/build/dir]
    insmod pebs-grabber.ko 
    # needs to record as root
-   perf record -e cycles:p,pebs_v1,pebs_v2 [command, -a for all etc.]
+   perf record -e cycles:p,pebs:pebs_v1,pebs:pebs_v2 [command, -a for all etc.]
    perf report
    perf script to display pebs data
    # alternatively trace-cmd and kernelshark can be also used to dump

--- a/pebs-grabber/pebs.h
+++ b/pebs-grabber/pebs.h
@@ -58,6 +58,18 @@ TRACE_EVENT(pebs_v2,
 		      __entry->ax)
 	);
 
+TRACE_EVENT(pebs_v3,
+	    TP_PROTO(u64 tsc),
+	    TP_ARGS(tsc),
+	    TP_STRUCT__entry(
+		    __field(u64, tsc)
+		    ),
+	    TP_fast_assign(
+		    __entry->tsc = tsc;
+		    ),
+	    TP_printk("tsc=%llx\n", __entry->tsc)
+	);
+
 TRACE_EVENT(pebs_regs, 
 	    TP_PROTO(u64 flags, u64 *regs),
 	    TP_ARGS(flags, regs),


### PR DESCRIPTION
1. support pebs v3
2. I don't have a CPU with pebs_v4, and I'm not quite sure how to present the pebs record for v4 in a better way. Therefore, I haven't submitted support for v4 related features.