### PR TITLE
Enable automatic version bumping with bumpver

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          python3 -m pip install --upgrade pip
-          python3 -m pip install build
+          python3 -m pip install --upgrade pip bumpver build
+          bumpver update --patch
           python3 -m build
 
       - name: Publish package distributions to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pmu_tools"
-version = "2025.6.2"
+version = "2025.6.7.0"
 authors = [
   { name="Andi Kleen", email="pmu-tools@halobates.de" },
 ]
@@ -40,11 +40,9 @@ packages = ["/"]
 ]
 
 [tool.bumpver]
-current_version = "{version}"
+current_version = "2025.6.7.0"
 # Choose a PEP 440 compatible regex
 version_pattern = "YYYY.MM.DD.PATCH"
-tag_message = "{new_version}"
-tag_scope = "default"
 pre_commit_hook = ""
 post_commit_hook = ""
 commit = false
@@ -54,8 +52,4 @@ push = false
 [tool.bumpver.file_patterns]
 "pyproject.toml" = [
     'version = "{version}"',
-]
-"README.md" = [
-    "{version}",
-    "{pep440_version}",
 ]


### PR DESCRIPTION
I've enabled automated CalVersioning. The main benefit is that we don't have to store the previous version to generate the new version.

Con:
We don't know the current version from code.

One more request:
- Please remove the authorization for my repo from your pypi account. I pushed to master and then it updated to your pypi account's releases.