### PR TITLE
Enable migration for ocperf into an installable script

### DIFF
--- a/ocperf.py
+++ b/ocperf.py
@@ -1241,3 +1241,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/ocperf.py
+++ b/ocperf.py
@@ -1213,7 +1213,10 @@ def find_pmus():
         g = ["/sys/bus/event_source/devices/cpu"]
     return [i.replace("/sys/bus/event_source/devices/", "") for i in g]
 
-if __name__ == '__main__':
+
+def main():
+    global force_download, experimental, noexplode
+    global msr
     for j in sys.argv:
         if j == "--force-download":
             force_download = True
@@ -1234,3 +1237,7 @@ if __name__ == '__main__':
         perf_cmd(cmd)
     except KeyboardInterrupt:
         pass
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ push = false
 "pyproject.toml" = [
     'version = "{version}"',
 ]
+
+[project.scripts]
+ocperf = "ocperf:main"


### PR DESCRIPTION
This PR is a proof of concept that enables me to use ocperf for PGO while using pmu-tools as an installable artifact (https://gcc.gnu.org/wiki/AutoFDO/Tutorial). 

Test Plan:
Instead of adding pmu tools to my path:
1. I created a venv
2. pip install .
3. went to a directory not containing ocperf and then ran the following commands

```

which ocperf
/home/snihalani/pmu-tools/venv/bin/ocperf

cat /home/snihalani/pmu-tools/venv/bin/ocperf
import re
import sys
from ocperf import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())

ocperf record ls
perf record ls
perf.data  test_file
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 0.015 MB perf.data (11 samples) ]
((venv) )

ocperf script
perf script
       perf-exec 3591082 238954.632897:          1 cycles:P:  ffffffff8aec5ad6 native_write_msr+0x6 ([kern>
              ls 3591082 238954.633037:      12191 cycles:P:  ffffffff8b003e70 hrtimer_forward+0x0 ([kerne>
              ls 3591082 238954.633052:      13368 cycles:P:  ffffffff8aec5ad6 native_write_msr+0x6 ([kern>
              ls 3591082 238954.633066:      40787 cycles:P:  ffffffff8af68e1b __update_blocked_fair+0xcb >
              ls 3591082 238954.633089:     121077 cycles:P:  ffffffff8bf91e36 copy_page_regs+0x26 ([kerne>
              ls 3591082 238954.633136:     274901 cycles:P:      76701bccbf48 init_cpu_features.constprop>
              ls 3591082 238954.633235:     422672 cycles:P:  ffffffff8b261ae7 kmem_cache_free+0x117 ([ker>
              ls 3591082 238954.633386:     503787 cycles:P:  ffffffff8bf7ca3d mas_preallocate+0x2d ([kern>
              ls 3591082 238954.633565:     545088 cycles:P:      76701bcc303b _dl_relocate_object+0x2db (>
              ls 3591082 238954.633758:     571942 cycles:P:  ffffffff8bf79a0f mas_split.isra.0+0x4cf ([ke>
              ls 3591082 238954.633966:     593169 cycles:P:  ffffffff8bd76067 genlmsg_put+0x17 ([kernel.k
```