### PR TITLE
Migrate toplev to an installable script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ jevents is a C library. It has no dependencies other than gcc/make and can be bu
 	cd jevents
 	make
 
+# Install via pip
+pip install pmu-tools
+
+
 # Quick examples
 
 	toplev -l2 program

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,12 @@ push = false
 
 [project.scripts]
 ocperf = "ocperf:main"
+toplev = "toplev:main"
+
+[project.optional-dependencies]
+plots = [
+"matplotlib",
+"brewer2mpl",
+"pandas",
+"xlsxwriter",
+]

--- a/toplev.py
+++ b/toplev.py
@@ -4643,12 +4643,11 @@ def finish_graph(graphp):
 def main():
     global args
     global rest_
-    global features
     global ectx
     global env_
     global cpu
     global feat
-    
+
     args, rest_ = init_args()
     feat = PerfFeatures(args)
     ectx = EventContextBase() # only for type checker


### PR DESCRIPTION
Test Plan:
```
which toplev                                                                                         -254-
/home/snihalani/pmu-tools/venv/bin/toplev
((venv) )

cat /home/snihalani/pmu-tools/venv/bin/toplev
import re
import sys
from toplev import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())

((venv) )
toplev --tune FUZZYINPUT=True
^C# 5.01-full-perf on Intel(R) Xeon(R) Gold 6226R CPU @ 2.90GHz [clx/skylake]
FE               Frontend_Bound  % Slots                       37.3  <==
    This category represents fraction of slots where the
    processor's Frontend undersupplies its Backend...
    Sampling events:  frontend_retired.latency_ge_4
BE               Backend_Bound   % Slots                       33.0
Run toplev --describe Frontend_Bound^ to get more information on bottleneck
Add --run-sample to find locations
Add --nodes '!+Frontend_Bound*/2,+MUX' for breakdown.
```