### PR TITLE
toplev: fix ValueError on string to float conversion.

### DIFF
--- a/toplev.py
+++ b/toplev.py
@@ -2469,7 +2469,7 @@ def do_execute(rlist, summary, evstr, flat_rmap, out, rest, resoff, revnum):
         multiplex = float('nan')
         event = event.rstrip()
         if re.match(r"\s*[0-9.]+", count):
-            val = float(count)
+            val = float(count.replace(",", "."))
         elif re.match(r"\s*<", count):
             account[event].errors[count.replace("<","").replace(">","")] += 1
             multiplex = 0.


### PR DESCRIPTION
Error: 

```
Traceback (most recent call last):
  File "/home/ivafanas/tools/pmu-tools/pmu-tools/toplev.py", line 4707, in <module>
    main(args, rest_, feat, env_, cpu)
  File "/home/ivafanas/tools/pmu-tools/pmu-tools/toplev.py", line 4683, in main
    ret = measure(out, orig_smt_mode, rest, runner_list, full_system)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ivafanas/tools/pmu-tools/pmu-tools/toplev.py", line 4620, in measure
    ret, count, full_system = measure_and_sample(runner_list, 0 if args.drilldown else None, out,
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ivafanas/tools/pmu-tools/pmu-tools/toplev.py", line 4552, in measure_and_sample
    ret = execute(runner_list, out, rrest, summary)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ivafanas/tools/pmu-tools/pmu-tools/toplev.py", line 2145, in execute
    for ret, res, rev, interval, valstats, env in do_execute(
  File "/home/ivafanas/tools/pmu-tools/pmu-tools/toplev.py", line 2475, in do_execute
    val = float(count)
```

Reproduced with command line:

```
python3 ~/tools/pmu-tools/pmu-tools/toplev.py --all --single-thread -- git status
```

Parsed line in `do_execute` function where exception happens:

```
0,06;Joules;power/energy-cores/;23284977;100,00;;
```

env:

```
$ perf --version
perf version 6.8.12

$ uname -a
Linux ivafanas-nb 6.8.0-79-generic #79-Ubuntu SMP PREEMPT_DYNAMIC Tue Aug 12 14:42:46 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux

$ cat /proc/cpuinfo | grep model | head -2
model		: 186
model name	: 13th Gen Intel(R) Core(TM) i7-13620H
```

Seems like either `re.match` should be replaced with `re.fullmatch` (to filter out event) or `float(count)` should be replaced with `float(count.replace(",", "."))` (to parse value properly).